### PR TITLE
Add End.not_found terminus in Model macro

### DIFF
--- a/lib/trailblazer/macro/model.rb
+++ b/lib/trailblazer/macro/model.rb
@@ -1,5 +1,8 @@
 module Trailblazer::Macro
-  def self.Model(model_class, action = nil, find_by_key = nil)
+
+  Linear = Trailblazer::Activity::DSL::Linear
+
+  def self.Model(model_class, action = nil, find_by_key = nil, id: 'model.build', not_found_end: false)
     task = Trailblazer::Activity::TaskBuilder::Binary(Model.new)
 
     injection = Trailblazer::Activity::TaskWrap::Inject::Defaults::Extension(
@@ -8,7 +11,10 @@ module Trailblazer::Macro
       :"model.find_by_key"    => find_by_key
     )
 
-    {task: task, id: "model.build", extensions: [injection]}
+    options = { task: task, id: id, extensions: [injection] }
+    options = options.merge(Linear::Output(:failure) => Linear::End(:not_found)) if not_found_end
+
+    options
   end
 
   class Model

--- a/test/docs/model_test.rb
+++ b/test/docs/model_test.rb
@@ -45,6 +45,13 @@ class DocsModelTest < Minitest::Spec
   end
   #:update-with-find-by-key end
 
+  #:update-with-not-found-end
+  class UpdateFailureWithModelNotFound < Trailblazer::Operation
+    step Model( Song, :find_by, not_found_end: true )
+    # ..
+  end
+  #:update-with-not-found-end end
+
   it do
     #:update-ok
     result = Update.(params: { id: 1 })
@@ -81,6 +88,19 @@ class DocsModelTest < Minitest::Spec
     #:update-with-find-by-key-fail end
     result[:model].must_be_nil
     result.success?.must_equal false
+  end
+
+  it do
+    #:update-with-not-found-end-use
+    result = UpdateFailureWithModelNotFound.(params: {title: nil})
+    result[:model] #=> nil
+    result.success? #=> false
+    result.event #=> #<Trailblazer::Activity::End semantic=:not_found>
+    #:update-with-not-found-end-use end
+
+    result[:model].must_be_nil
+    result.success?.must_equal false
+    result.event.inspect.must_equal %{#<Trailblazer::Activity::End semantic=:not_found>}
   end
 
   #:show

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,9 +1,10 @@
+$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+require "trailblazer/macro"
+
 require "delegate" # Ruby 2.2
 require "minitest/autorun"
 
 require "trailblazer/developer"
-require "trailblazer/macro"
-
 
 module Mock
   class Result

--- a/trailblazer-macro.gemspec
+++ b/trailblazer-macro.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "roar"
   spec.add_development_dependency "trailblazer-developer"
 
-  spec.add_dependency "trailblazer-operation", ">= 0.6.0" # TODO: this dependency will be removed.
+  spec.add_dependency "trailblazer-operation", ">= 0.6.2" # TODO: this dependency will be removed.
 
   spec.required_ruby_version = ">= 2.2.0"
 end


### PR DESCRIPTION
Optional support to add `End.not_found` terminus if model is not found.

`step Model( Song, :find, not_found_end: true )`