### PR TITLE
Remove warn in Nested() about using Subprocess

### DIFF
--- a/lib/trailblazer/macro/nested.rb
+++ b/lib/trailblazer/macro/nested.rb
@@ -4,7 +4,6 @@ module Trailblazer
     # {Nested} macro.
     def self.Nested(callable, id: "Nested(#{callable})")
       if callable.is_a?(Class) && callable < Nested.operation_class
-        warn %{[Trailblazer] Using the `Nested()` macro with operations and activities is deprecated. Replace `Nested(Create)` with `Subprocess(Create)`.}
         return Nested.operation_class.Subprocess(callable)
       end
 


### PR DESCRIPTION
It is decided that both can be used interchangeably in
activity/operation to do static nesting.