### PR TITLE
Use Linear::Helper to introduce macros in activities scope

### DIFF
--- a/lib/trailblazer/macro.rb
+++ b/lib/trailblazer/macro.rb
@@ -1,5 +1,6 @@
+require "forwardable"
 require "trailblazer/activity"
-require "trailblazer/activity/dsl/linear" # TODO: remove this dependency
+require "trailblazer/activity/dsl/linear"
 require "trailblazer/operation" # TODO: remove this dependency
 
 require "trailblazer/macro/model"
@@ -12,18 +13,16 @@ require "trailblazer/macro/wrap"
 
 module Trailblazer
   module Macro
-    # All macros sit in the {Trailblazer::Macro} namespace, where we forward calls from
-    # operations and activities to.
-    def self.forward_macros(target)
-      target.singleton_class.def_delegators Trailblazer::Macro, :Model, :Wrap, :Rescue, :Nested
-      target.const_set(:Policy, Trailblazer::Macro::Policy)
-    end
   end
+
+  # All macros sit in the {Trailblazer::Macro} namespace, where we forward calls from
+  # operations and activities to.
+  module Activity::DSL::Linear::Helper
+    Policy = Trailblazer::Macro::Policy
+
+    module ClassMethods
+      extend Forwardable
+      def_delegators Trailblazer::Macro, :Model, :Nested, :Wrap, :Rescue
+    end # ClassMethods
+  end # Helper
 end
-
-# TODO: Forwardable.def_delegators(Operation, Macro, :Model, :Wrap) would be amazing. It really sucks to extend a foreign class.
-# Trailblazer::Operation.singleton_class.extend Forwardable
-# Trailblazer::Macro.forward_macros(Trailblazer::Operation)
-
-Trailblazer::Activity::FastTrack.singleton_class.extend Forwardable
-Trailblazer::Macro.forward_macros(Trailblazer::Activity::FastTrack) # monkey-patching sucks.

--- a/trailblazer-macro.gemspec
+++ b/trailblazer-macro.gemspec
@@ -25,6 +25,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "roar"
   spec.add_development_dependency "trailblazer-developer"
 
+  spec.add_dependency "trailblazer-activity", ">= 0.10.0", "< 1.0.0"
+  spec.add_dependency "trailblazer-activity-dsl-linear", ">= 0.2.7", "< 1.0.0"
   spec.add_dependency "trailblazer-operation", ">= 0.6.2" # TODO: this dependency will be removed.
 
   spec.required_ruby_version = ">= 2.2.0"


### PR DESCRIPTION
This uses native way to introduce macros in all types activities by opening `Linear::Helper` module.