### PR TITLE
Add di-call doc test back to fix trb-website build

### DIFF
--- a/test/docs/guard_test.rb
+++ b/test/docs/guard_test.rb
@@ -109,6 +109,27 @@ class DocsGuardNamedTest < Minitest::Spec
 end
 
 #---
+# dependency injection
+class DocsGuardInjectionTest < Minitest::Spec
+  #:di-op
+  class Create < Trailblazer::Operation
+    step Policy::Guard( ->(options, current_user:, **) { current_user == Module } )
+  end
+  #:di-op end
+
+  it { Create.(:current_user => Module).inspect("").must_equal %{<Result:true [nil] >} }
+  it {
+    result =
+  #:di-call
+  Create.(
+    :current_user           => Module,
+    :"policy.default.eval"  => Trailblazer::Operation::Policy::Guard.build(->(options, **) { false })
+  )
+  #:di-call end
+    result.inspect("").must_equal %{<Result:false [nil] >} }
+end
+
+#---
 # missing current_user throws exception
 class DocsGuardMissingKeywordTest < Minitest::Spec
   class Create < Trailblazer::Operation


### PR DESCRIPTION
Old test was using deprecated `Trailblazer::Operation::Container`.
PR in which it was removed - https://github.com/trailblazer/trailblazer-macro/pull/32.