### PR TITLE
Show activity name and caller location in `Nested()` warning

### DIFF
--- a/lib/trailblazer/macro/nested.rb
+++ b/lib/trailblazer/macro/nested.rb
@@ -4,7 +4,11 @@ module Trailblazer
     # {Nested} macro.
     def self.Nested(callable, id: "Nested(#{callable})", auto_wire: [])
       if callable.is_a?(Class) && callable < Nested.operation_class
-        warn %{[Trailblazer] Using the `Nested()` macro with operations and activities is deprecated. Replace `Nested(Create)` with `Subprocess(Create)`.}
+        caller_location = caller_locations(2, 1)[0]
+        warn "[Trailblazer]#{caller_location.absolute_path}: " \
+             "Using the `Nested()` macro with operations and activities is deprecated. " \
+             "Replace `Nested(#{callable})` with `Subprocess(#{callable})`."
+
         return Nested.operation_class.Subprocess(callable)
       end
 

--- a/test/operation/nested_test.rb
+++ b/test/operation/nested_test.rb
@@ -62,4 +62,15 @@ class NestedTest < Minitest::Spec
 
     exception.inspect.must_match 'No `db_error` output found'
   end
+
+  it "shows warning if `Nested()` is being used instead of `Subprocess()` for static activities" do
+    _, warnings = capture_io do
+      Class.new(Trailblazer::Operation) do
+        step Nested(SignUp)
+      end
+    end
+
+    warnings.must_equal %Q{[Trailblazer]#{__FILE__}: Using the `Nested()` macro with operations and activities is deprecated. Replace `Nested(NestedTest::SignUp)` with `Subprocess(NestedTest::SignUp)`.
+}
+  end
 end


### PR DESCRIPTION
Instead of a static text, include activity name and location to identify deeply nested activities too.

```ruby

# old

[Trailblazer] Using the `Nested()` macro with operations and activities is deprecated. Replace `Nested(Create)` with `Subprocess(Create)`

# new

[Trailblazer]app/concepts/user/update.rb: Using the `Nested()` macro with operations and activities is deprecated. Replace `Nested(User::Update)` with `Subprocess(User::Update)`.

```