### PR TITLE
Adding If Macro

### DIFF
--- a/lib/trailblazer/macro.rb
+++ b/lib/trailblazer/macro.rb
@@ -11,6 +11,7 @@ require "trailblazer/macro/nested"
 require "trailblazer/macro/rescue"
 require "trailblazer/macro/wrap"
 require "trailblazer/macro/each"
+require "trailblazer/macro/if"
 
 module Trailblazer
   module Macro
@@ -74,6 +75,6 @@ module Trailblazer
     # Extending the {Linear::Helper} namespace is the canonical way to import
     # macros into Railway, FastTrack, Operation, etc.
     extend Forwardable
-    def_delegators Trailblazer::Macro, :Model, :Nested, :Wrap, :Rescue, :Each
+    def_delegators Trailblazer::Macro, :Model, :Nested, :Wrap, :Rescue, :Each, :If
   end # Helper
 end

--- a/lib/trailblazer/macro/if.rb
+++ b/lib/trailblazer/macro/if.rb
@@ -1,0 +1,46 @@
+require 'securerandom'
+
+module Trailblazer
+  module Macro
+    # Condition can be anything to be fetched from context.
+    # String, Symbol or Hash preferred.
+    # Example:
+    #   String => 'string' -> ctx['string']
+    #   Symbol => :symbol -> ctx[:symbol]
+    #   Hash => {params: :condition} -> ctx[:params][:condition]
+    def self.If(condition = { params: :condition }, &block)
+      keys_to_dig = If::UNDIGGABLE_KEY_TYPES.include?(condition.class) ? [condition] : If.keys(condition)
+
+      if_block = lambda do |(ctx, flow_options), **, &nested_activities|
+        return [Trailblazer::Activity::Right, [ctx, flow_options]] unless If.condition(ctx, keys_to_dig)
+
+        nested_activities.call
+      end
+
+      Wrap(if_block, id: "If(#{SecureRandom.hex(4)})", &block)
+    end
+
+    module If
+      UNDIGGABLE_KEY_TYPES = [String, Symbol, Integer].freeze
+
+      def self.keys(condition)
+        result = []
+        condition.each do |k, v|
+          result << k
+          if UNDIGGABLE_KEY_TYPES.include?(v.class)
+            result << v
+          else
+            result.concat keys(v)
+          end
+        end
+        result
+      end
+
+      def self.condition(context, keys_to_dig)
+        return context[keys_to_dig.first] if keys_to_dig.size == 1
+
+        keys_to_dig.reduce(context) { |digged, k| digged.try(:[], k) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
There have been many cases in my current organisation where, let's say we have to skip some steps based on one specific condition, there was no inherent If handler available which would have helped us to skip those steps (and we had to rely on many guard statements). So for that, I decided to implement this PR as a proof of concept.

Let's say, we have a sample operation:

```ruby
class Operation
  step :first
  step :second
  step :third
  step :fourth

  ...
end
```

And the steps second and third need to be conditionally executed based on the response from the first step. In the original case, we'll have to add 'n' number of guard clauses (where n are the steps to be skipped) in those steps. However, Introducing the If macro, we can add a truthy value in context[:params][:condition_key], and wrap those two steps something like this

```ruby
class Operation
  step :first 
  step If({params: :condition_key}) {
    step :second
    step :third
  }
  step :fourth
end
```

In this case, we don't have to write guard clauses and those steps will be only executed on the basis of the given condition.