### PR TITLE
Remove runtime dependency of trailblazer-operation

### DIFF
--- a/lib/trailblazer/macro.rb
+++ b/lib/trailblazer/macro.rb
@@ -1,6 +1,5 @@
 require "forwardable"
 require "trailblazer/activity/dsl/linear"
-require "trailblazer/operation" # TODO: remove this dependency
 
 require "trailblazer/macro/strategy"
 require "trailblazer/macro/model"

--- a/lib/trailblazer/macro/guard.rb
+++ b/lib/trailblazer/macro/guard.rb
@@ -9,7 +9,7 @@ module Trailblazer::Macro
         option = Trailblazer::Option(callable)
 
         ->((ctx, *), **circuit_args) do
-          Trailblazer::Operation::Result.new(!!option.call(ctx, keyword_arguments: ctx.to_hash, **circuit_args), {})
+          Policy::Result.new(result: !!option.call(ctx, keyword_arguments: ctx.to_hash, **circuit_args))
         end
       end
     end

--- a/lib/trailblazer/macro/policy.rb
+++ b/lib/trailblazer/macro/policy.rb
@@ -20,9 +20,33 @@ module Trailblazer::Macro
         ctx[:"result.policy.#{@name}"] = result
 
         # flow control
-        signal = result.success? ? Trailblazer::Activity::Right : Trailblazer::Activity::Left
+        signal = result[:result] ? Trailblazer::Activity::Right : Trailblazer::Activity::Left
 
         return signal, [ctx, flow_options]
+      end
+    end
+
+    class Result < Hash
+      def initialize(result:, data: nil)
+        self[:result] = result
+
+        data.each { |k, v| self[k] = v } if data
+      end
+
+      def success?
+        Trailblazer::Activity::Deprecate.warn caller_locations[0],
+          "The `success?` method is deprecated and will be removed in 3.0.0. " \
+          "Use `ctx[\"result.policy.\#{name}\"][:result]` instead."
+
+        self[:result]
+      end
+
+      def failure?
+        Trailblazer::Activity::Deprecate.warn caller_locations[0],
+          "The `failure?` method is deprecated and will be removed in 3.0.0. " \
+          "Use `!ctx[\"result.policy.\#{name}\"][:result]` instead."
+
+        !self[:result]
       end
     end
 

--- a/lib/trailblazer/macro/pundit.rb
+++ b/lib/trailblazer/macro/pundit.rb
@@ -30,7 +30,7 @@ module Trailblazer::Macro
           data = { policy: policy }
           data[:message] = "Breach" if !success # TODO: how to allow messages here?
 
-          Trailblazer::Operation::Result.new(success, data)
+          Policy::Result.new(result: success, data: data)
         end
       end
     end

--- a/lib/trailblazer/macro/rescue.rb
+++ b/lib/trailblazer/macro/rescue.rb
@@ -18,7 +18,7 @@ module Trailblazer
           # DISCUSS: should we deprecate this signature and rather apply the Task API here?
           handler.call(exception, ctx, **circuit_options) # FIXME: when there's an error here, it shows the wrong exception!
 
-          [Operation::Railway.fail!, [ctx, flow_options]]
+          [Activity::Left, [ctx, flow_options]]
         end
       end
 

--- a/test/docs/guard_test.rb
+++ b/test/docs/guard_test.rb
@@ -20,8 +20,8 @@ class DocsGuardProcTest < Minitest::Spec
   it { Create.(pass: true)[:x].must_equal true }
 
   #- result object, guard
-  it { Create.(pass: true)[:"result.policy.default"].success?.must_equal true }
-  it { Create.(pass: false)[:"result.policy.default"].success?.must_equal false }
+  it { Create.(pass: true)[:"result.policy.default"][:result].must_equal true }
+  it { Create.(pass: false)[:"result.policy.default"][:result].must_equal false }
 
   #---
   #- Guard inheritance
@@ -97,13 +97,13 @@ class DocsGuardNamedTest < Minitest::Spec
   end
   #:name end
 
-  it { Create.(:current_user => nil   )[:"result.policy.user"].success?.must_equal false }
-  it { Create.(:current_user => Module)[:"result.policy.user"].success?.must_equal true }
+  it { Create.(:current_user => nil   )[:"result.policy.user"][:result].must_equal false }
+  it { Create.(:current_user => Module)[:"result.policy.user"][:result].must_equal true }
 
   it {
   #:name-result
   result = Create.(:current_user => true)
-  result[:"result.policy.user"].success? #=> true
+  result[:"result.policy.user"][:result] #=> true
   #:name-result end
   }
 end

--- a/test/operation/pundit_test.rb
+++ b/test/operation/pundit_test.rb
@@ -29,7 +29,7 @@ class PolicyTest < Minitest::Spec
     result = Create.(params: {}, current_user: Module)
     result[:process].must_equal true
     #- result object, policy
-    result[:"result.policy.default"].success?.must_equal true
+    result[:"result.policy.default"][:result].must_equal true
     result[:"result.policy.default"][:message].must_be_nil
     # result[:valid].must_be_nil
     result[:"policy.default"].inspect.must_equal %{<Auth: user:Module, model:nil>}
@@ -39,7 +39,7 @@ class PolicyTest < Minitest::Spec
     result = Create.(params: {}, current_user: nil)
     result[:process].must_be_nil
     #- result object, policy
-    result[:"result.policy.default"].success?.must_equal false
+    result[:"result.policy.default"][:result].must_equal false
     result[:"result.policy.default"][:message].must_equal "Breach"
   end
   # inject different policy.Condition  it { Create.(params: {}, current_user: Object, "policy.default.eval" => Trailblazer::Operation::Policy::Pundit::Condition.new(Auth, :user_object?))["process"].must_equal true }
@@ -88,7 +88,7 @@ class PolicyTest < Minitest::Spec
     result = Edit.(params: { id: 1 }, current_user: Module)
     result[:process].must_equal true
     result[:model].inspect.must_equal %{#<struct PolicyTest::Song id=1>}
-    result[:"result.policy.default"].success?.must_equal true
+    result[:"result.policy.default"][:result].must_equal true
     result[:"result.policy.default"][:message].must_be_nil
     # result[:valid].must_be_nil
     result[:"policy.default"].inspect.must_equal %{<Auth: user:Module, model:#<struct PolicyTest::Song id=1>>}
@@ -99,7 +99,7 @@ class PolicyTest < Minitest::Spec
     result = Edit.(params: { id: 4 }, current_user: nil)
     result[:model].inspect.must_equal %{#<struct PolicyTest::Song id=4>}
     result[:process].must_be_nil
-    result[:"result.policy.default"].success?.must_equal false
+    result[:"result.policy.default"][:result].must_equal false
     result[:"result.policy.default"][:message].must_equal "Breach"
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,9 +1,10 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require "minitest/autorun"
 
-require "trailblazer/macro"
 require "trailblazer/developer"
+require "trailblazer/operation"
 require "trailblazer/activity/testing"
+require "trailblazer/macro"
 
 T = Trailblazer::Activity::Testing
 

--- a/trailblazer-macro.gemspec
+++ b/trailblazer-macro.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "trailblazer-developer"
-  spec.add_dependency "trailblazer-operation", ">= 0.10.0" # TODO: this dependency will be removed. currently needed for tests and for Guard::Result
+  spec.add_development_dependency "trailblazer-operation"
 
   spec.add_dependency "trailblazer-activity-dsl-linear", ">= 1.2.0", "< 1.3.0"
 


### PR DESCRIPTION
First part of #45

1. Define `Policy::Result` to replace `Operation::Result` and warn about `success?` and `failure?` depreciation.
2. Make `trailblazer-operation` as development dependency in order to use in tests.